### PR TITLE
Add a nix flake for tkn-watch

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,16 @@
+on: [push, pull_request]
+
+name: Nix CI
+
+jobs:
+  test:
+    name: Build and Test using Nix
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix build
+    - run: nix flake check

--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ yay -S tkn-watch-bin
 docker run -i ghcr.io/chmouel/tkn-watch # don't forget to bind your kubeconfig
 ```
 
+### [Nix/NixOS](https://nixos.org/)
+
+This repository comes with a `flake` (see [NixOS Wiki on
+Flakes](https://nixos.wiki/wiki/Flakes)).
+
+If you have the `nix flake` command enable (currenty on
+nixos-unstable, `nixos-version` >= 22.05)
+
+```shell
+nix run github:chmouel/tkn-watch -- --help # your args are here
+```
+
+You can also use to test and develop on the repository.
+
+```shell
+nix develop # drops you in a shell with all the thing needed
+nix flake check # runs cargo test, rustfmt, …
+```
 ## Usage
 
 ```shell

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, naersk
+, stdenv
+, clangStdenv
+, hostPlatform
+, targetPlatform
+, pkg-config
+, libiconv
+, rustfmt
+, cargo
+, rustc
+}:
+
+let
+  cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
+in
+
+naersk.lib."${targetPlatform.system}".buildPackage rec {
+  src = ./.;
+
+  buildInputs = [
+    rustfmt
+    pkg-config
+    cargo
+    rustc
+    libiconv
+  ];
+  checkInputs = [ cargo rustc ];
+
+  doCheck = true;
+  CARGO_BUILD_INCREMENTAL = "false";
+  RUST_BACKTRACE = "full";
+  copyLibs = true;
+
+  name = cargoToml.package.name;
+  version = cargoToml.package.version;
+
+  meta = with lib; {
+    description = cargoToml.package.description;
+    homepage = cargoToml.package.homepage;
+    license = with licenses; [ mit ];
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,7 @@
 , rustfmt
 , cargo
 , rustc
+, openssl
 }:
 
 let
@@ -18,14 +19,16 @@ in
 naersk.lib."${targetPlatform.system}".buildPackage rec {
   src = ./.;
 
+  nativeBuildInputs = [ pkg-config ];
   buildInputs = [
     rustfmt
     pkg-config
     cargo
     rustc
     libiconv
+    openssl
   ];
-  checkInputs = [ cargo rustc ];
+  checkInputs = [ cargo rustc ]; # just for the host building the package
 
   doCheck = true;
   CARGO_BUILD_INCREMENTAL = "false";
@@ -38,7 +41,7 @@ naersk.lib."${targetPlatform.system}".buildPackage rec {
   meta = with lib; {
     description = cargoToml.package.description;
     homepage = cargoToml.package.homepage;
-    license = with licenses; [ mit ];
-    maintainers = with maintainers; [ ];
+    license = with licenses; [ asl20 ];
+    maintainers = with maintainers; [ vdemeester chmouel ];
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1651574473,
+        "narHash": "sha256-wQhFORvRjo8LB2hTmETmv6cbyKGDPbfWqvZ/0chnDE4=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "f21309b38e1da0d61b881b6b6d41b81c1aed4e1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1652252629,
+        "narHash": "sha256-SvT64apetqc8P5nYp1/fOZvUmHUPdPFUZbhSpKy+1aI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d2fc6856824cb87742177eefc8dd534bdb6c3439",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,78 @@
+{
+  description = "tkn-watch - watch a PipelineRuns on its way to success or failures";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    naersk.url = "github:nix-community/naersk";
+    naersk.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, naersk }:
+    let
+      cargoToml = (builtins.fromTOML (builtins.readFile ./Cargo.toml));
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in
+    {
+      overlays.default = final: prev: {
+        "${cargoToml.package.name}" = final.callPackage ./. { inherit naersk; };
+      };
+
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              self.overlays.default
+            ];
+          };
+        in
+        {
+          "${cargoToml.package.name}" = pkgs."${cargoToml.package.name}";
+        });
+
+
+      defaultPackage = forAllSystems (system: (import nixpkgs {
+        inherit system;
+        overlays = [ self.overlays.default ];
+      })."${cargoToml.package.name}");
+
+      checks = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [
+              self.overlays.default
+            ];
+          };
+        in
+        {
+          format = pkgs.runCommand "check-format"
+            {
+              buildInputs = with pkgs; [ rustfmt cargo ];
+            } ''
+            ${pkgs.rustfmt}/bin/cargo-fmt fmt --manifest-path ${./.}/Cargo.toml -- --check
+            ${pkgs.nixpkgs-fmt}/bin/nixpkgs-fmt --check ${./.}
+            touch $out # it worked!
+          '';
+          "${cargoToml.package.name}" = pkgs."${cargoToml.package.name}";
+        });
+      devShell = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlays.default ];
+          };
+        in
+        pkgs.mkShell {
+          inputsFrom = with pkgs; [
+            pkgs."${cargoToml.package.name}"
+          ];
+          buildInputs = with pkgs; [
+            rustfmt
+            nixpkgs-fmt
+          ];
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        });
+    };
+}


### PR DESCRIPTION
This allow to run things tkn-watch like `nix run github:chmouel/tkn-watch --
--help`.
It also provides packages for other to integrate with their flake
configuration / nix derivation.

`nix develop` drops you in a development environment with everything
needed.
`nix flake check` runs all the tests (fmt, cargo test, …)

Signed-off-by: Vincent Demeester <vincent@sbr.pm>